### PR TITLE
fix：修复MPJTableInfoHelper.java的copyAndSetTableName中的潜在问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.yulichang</groupId>
     <artifactId>mybatis-plus-join</artifactId>
-    <version>1.2.4</version>
+    <version>1.2.5-SNAPSHOT</version>
     <name>mybatis-plus-join</name>
     <description>An enhanced toolkit of Mybatis-Plus to simplify development.</description>
     <url>https://github.com/yulichang/mybatis-plus-join</url>

--- a/src/main/java/com/baomidou/mybatisplus/core/metadata/MPJTableInfoHelper.java
+++ b/src/main/java/com/baomidou/mybatisplus/core/metadata/MPJTableInfoHelper.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -561,13 +562,16 @@ public class MPJTableInfoHelper {
             //反射拷贝对象
             Field[] fields = TableInfo.class.getDeclaredFields();
             for (Field f : fields) {
-                f.setAccessible(true);
-                f.set(table, f.get(tableInfo));
+//                jacoco 等测试覆盖率框架可能会增强TableInfo字节码，增加static字段
+                if (!Modifier.isStatic(f.getModifiers())) {
+                    f.setAccessible(true);
+                    f.set(table, f.get(tableInfo));
+                }
             }
             table.setTableName(tableName);
             return table;
         } catch (Exception e) {
-            throw new MPJException("TableInfo 对象拷贝失败 -> " + tableInfo.getEntityType().getName());
+            throw new MPJException("TableInfo 对象拷贝失败 -> " + tableInfo.getEntityType().getName(),e);
         }
     }
 }

--- a/src/main/java/com/github/yulichang/exception/MPJException.java
+++ b/src/main/java/com/github/yulichang/exception/MPJException.java
@@ -6,6 +6,9 @@ package com.github.yulichang.exception;
  * @author yulichang
  */
 public class MPJException extends RuntimeException {
+    public MPJException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
     public MPJException(String msg) {
         super(msg);


### PR DESCRIPTION
copyAndSetTableName方法中使用反射拷贝对象时剔除static字段的拷贝