### PR TITLE
复用wrapper，当增加新的查询条件后，sql未重新生成

### DIFF
--- a/mybatis-plus-join-core/src/main/java/com/github/yulichang/wrapper/MPJLambdaWrapper.java
+++ b/mybatis-plus-join-core/src/main/java/com/github/yulichang/wrapper/MPJLambdaWrapper.java
@@ -188,12 +188,14 @@ public class MPJLambdaWrapper<T> extends JoinAbstractLambdaWrapper<T, MPJLambdaW
                 SelectCache cache = cacheMap.get(LambdaUtils.getName(s));
                 getSelectColum().add(new SelectNormal(cache, index, hasAlias, alias));
             }
+            sqlSelect.toNull();
         }
         return typedThis;
     }
 
     @Override
     public MPJLambdaWrapper<T> selectAll(Class<?> clazz) {
+        sqlSelect.toNull();
         return Query.super.selectAll(clazz);
     }
 
@@ -234,6 +236,7 @@ public class MPJLambdaWrapper<T> extends JoinAbstractLambdaWrapper<T, MPJLambdaW
         addCustomWrapper(wrapper);
         String name = LambdaUtils.getName(alias);
         this.selectColumns.add(new SelectSub(() -> WrapperUtils.buildSubSqlByWrapper(clazz, wrapper, name), hasAlias, this.alias, name));
+        sqlSelect.toNull();
         return typedThis;
     }
 

--- a/mybatis-plus-join-test/test-mapping/src/test/java/com/github/yulichang/test/mapping/MappingTest.java
+++ b/mybatis-plus-join-test/test-mapping/src/test/java/com/github/yulichang/test/mapping/MappingTest.java
@@ -61,4 +61,14 @@ class MappingTest {
         assert dos.get(0).getArea() != null;
         dos.forEach(System.out::println);
     }
+
+    @Test
+    public void testReuseWrapper() {
+        MPJLambdaWrapper<UserDO> wrapper = new MPJLambdaWrapper<UserDO>()
+                .select(UserDO::getName);
+        List<UserDO> dos = userService.list(wrapper);
+        System.out.println(1);
+        wrapper.select(UserDO::getAddressId);
+        dos = userService.list(wrapper);
+    }
 }


### PR DESCRIPTION
### 该Pull Request关联的Issue
无

### 修改描述
复用wrapper，当增加新的查询条件后，sql未重新生成

### 测试用例
<code>
@Test
    public void testReuseWrapper() {
        MPJLambdaWrapper<UserDO> wrapper = new MPJLambdaWrapper<UserDO>()
                .select(UserDO::getName);
        List<UserDO> dos = userService.list(wrapper);
        System.out.println(1);
        wrapper.select(UserDO::getAddressId);
        dos = userService.list(wrapper);
    }
</code>

### 修复效果的截屏

修复前的sql输出日志：
<code>
Creating a new SqlSession
SqlSession [org.apache.ibatis.session.defaults.DefaultSqlSession@58a2b917] was not registered for synchronization because synchronization is not active
JDBC Connection [HikariProxyConnection@1328705686 wrapping conn0: url=jdbc:h2:mem:test user=ROOT] will not be managed by Spring
==>  Preparing: **SELECT t.`name` FROM `user` t WHERE t.del = false**
==> Parameters: 
<==    Columns: NAME
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==      Total: 22
Closing non transactional SqlSession [org.apache.ibatis.session.defaults.DefaultSqlSession@58a2b917]
1
Creating a new SqlSession
SqlSession [org.apache.ibatis.session.defaults.DefaultSqlSession@3a3ed300] was not registered for synchronization because synchronization is not active
JDBC Connection [HikariProxyConnection@972404515 wrapping conn0: url=jdbc:h2:mem:test user=ROOT] will not be managed by Spring
==>  Preparing: **SELECT t.`name` FROM `user` t WHERE t.del = false**
**=====================这里的sql没有查询t.address_id字段========================**
==> Parameters: 
<==    Columns: NAME
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==      Total: 22
Closing non transactional SqlSession [org.apache.ibatis.session.defaults.DefaultSqlSession@3a3ed300]
</code>

修复后的sql输出日志：
<code>
Creating a new SqlSession
SqlSession [org.apache.ibatis.session.defaults.DefaultSqlSession@58a2b917] was not registered for synchronization because synchronization is not active
JDBC Connection [HikariProxyConnection@1328705686 wrapping conn0: url=jdbc:h2:mem:test user=ROOT] will not be managed by Spring
==>  Preparing: **SELECT t.`name` FROM `user` t WHERE t.del = false**
==> Parameters: 
<==    Columns: NAME
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==        Row: {"aa":"aaa","bb":"bbb"}
<==      Total: 22
Closing non transactional SqlSession [org.apache.ibatis.session.defaults.DefaultSqlSession@58a2b917]
1
Creating a new SqlSession
SqlSession [org.apache.ibatis.session.defaults.DefaultSqlSession@3a3ed300] was not registered for synchronization because synchronization is not active
JDBC Connection [HikariProxyConnection@972404515 wrapping conn0: url=jdbc:h2:mem:test user=ROOT] will not be managed by Spring
==>  Preparing: **SELECT t.`name`, t.address_id FROM `user` t WHERE t.del = false**
==> Parameters: 
<==    Columns: NAME, ADDRESS_ID
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==        Row: {"aa":"aaa","bb":"bbb"}, 1
<==      Total: 22
Closing non transactional SqlSession [org.apache.ibatis.session.defaults.DefaultSqlSession@3a3ed300]

</code>