### PR TITLE
[修复] 去掉MPJLambdaQueryWrapper类的selectIgnore方法获取字段名时多加的一层表别名

### DIFF
--- a/mybatis-plus-join-core/src/main/java/com/github/yulichang/query/MPJLambdaQueryWrapper.java
+++ b/mybatis-plus-join-core/src/main/java/com/github/yulichang/query/MPJLambdaQueryWrapper.java
@@ -163,7 +163,7 @@ public class MPJLambdaQueryWrapper<T> extends AbstractLambdaWrapper<T, MPJLambda
     public final MPJLambdaQueryWrapper<T> selectIgnore(SFunction<T, ?>... columns) {
         if (ArrayUtils.isNotEmpty(columns)) {
             for (SFunction<T, ?> s : columns) {
-                ignoreColumns.add(alias + StringPool.DOT + columnToString(s));
+                ignoreColumns.add(columnToString(s));
             }
         }
         return typedThis;


### PR DESCRIPTION
参考问题：#328