### PR TITLE
feat: support MyBatis-Plus 3.5.17

### DIFF
--- a/mybatis-plus-join-adapter/mybatis-plus-join-adapter-base/src/main/java/com/github/yulichang/adapter/base/tookit/VersionUtils.java
+++ b/mybatis-plus-join-adapter/mybatis-plus-join-adapter-base/src/main/java/com/github/yulichang/adapter/base/tookit/VersionUtils.java
@@ -3,6 +3,8 @@ package com.github.yulichang.adapter.base.tookit;
 import com.baomidou.mybatisplus.core.MybatisPlusVersion;
 import com.baomidou.mybatisplus.core.toolkit.ExceptionUtils;
 
+import java.security.CodeSource;
+
 /**
  * 版本工具类
  *
@@ -11,7 +13,7 @@ import com.baomidou.mybatisplus.core.toolkit.ExceptionUtils;
  */
 public class VersionUtils {
 
-    public static String version = MybatisPlusVersion.getVersion();
+    public static String version = resolveMybatisPlusVersion();
 
     @SuppressWarnings("unused")
     public static void setMybatisPlusVersion(String version) {
@@ -25,6 +27,24 @@ public class VersionUtils {
             throw ExceptionUtils.mpe("mybatis-plus version is blank, " +
                     "please add VersionUtils.setMybatisPlusVersion(?) code before running application");
         }
+    }
+
+    private static String resolveMybatisPlusVersion() {
+        String version = MybatisPlusVersion.getVersion();
+        if (version != null) {
+            return version;
+        }
+        CodeSource codeSource = MybatisPlusVersion.class.getProtectionDomain().getCodeSource();
+        if (codeSource != null && codeSource.getLocation() != null) {
+            String location = codeSource.getLocation().toExternalForm();
+            String prefix = "mybatis-plus-core-";
+            int start = location.lastIndexOf(prefix);
+            int end = location.indexOf(".jar", start);
+            if (start >= 0 && end > start) {
+                return location.substring(start + prefix.length(), end);
+            }
+        }
+        return null;
     }
 
     public static int compare(String v1, String v2) {

--- a/mybatis-plus-join-core/src/main/java/com/github/yulichang/base/MPJBaseService.java
+++ b/mybatis-plus-join-core/src/main/java/com/github/yulichang/base/MPJBaseService.java
@@ -1,6 +1,6 @@
 package com.github.yulichang.base;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 
 /**
  * 基础service

--- a/mybatis-plus-join-core/src/main/java/com/github/yulichang/base/MPJBaseServiceImpl.java
+++ b/mybatis-plus-join-core/src/main/java/com/github/yulichang/base/MPJBaseServiceImpl.java
@@ -1,6 +1,6 @@
 package com.github.yulichang.base;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 
 /**
  * @author yulichang

--- a/mybatis-plus-join-core/src/main/java/com/github/yulichang/repository/JoinCrudRepository.java
+++ b/mybatis-plus-join-core/src/main/java/com/github/yulichang/repository/JoinCrudRepository.java
@@ -1,7 +1,7 @@
 package com.github.yulichang.repository;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import com.baomidou.mybatisplus.extension.repository.CrudRepository;
+import com.baomidou.mybatisplus.spring.repository.CrudRepository;
 
 /**
  * {@link CrudRepository}

--- a/mybatis-plus-join-extension/src/main/java/com/github/yulichang/extension/mapping/base/MPJDeepService.java
+++ b/mybatis-plus-join-extension/src/main/java/com/github/yulichang/extension/mapping/base/MPJDeepService.java
@@ -2,7 +2,7 @@ package com.github.yulichang.extension.mapping.base;
 
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import com.github.yulichang.annotation.EntityMapping;
 import com.github.yulichang.annotation.FieldMapping;
 import com.github.yulichang.extension.mapping.config.DeepConfig;

--- a/mybatis-plus-join-extension/src/main/java/com/github/yulichang/extension/mapping/base/MPJRelationService.java
+++ b/mybatis-plus-join-extension/src/main/java/com/github/yulichang/extension/mapping/base/MPJRelationService.java
@@ -1,7 +1,7 @@
 package com.github.yulichang.extension.mapping.base;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import com.github.yulichang.annotation.EntityMapping;
 import com.github.yulichang.annotation.FieldMapping;
 import com.github.yulichang.extension.mapping.config.DeepConfig;

--- a/mybatis-plus-join-test/test-join/src/main/java/com/github/yulichang/test/join/entity/ID.java
+++ b/mybatis-plus-join-test/test-join/src/main/java/com/github/yulichang/test/join/entity/ID.java
@@ -1,7 +1,7 @@
 package com.github.yulichang.test.join.entity;
 
 import com.baomidou.mybatisplus.annotation.TableId;
-import com.baomidou.mybatisplus.extension.activerecord.Model;
+import com.baomidou.mybatisplus.spring.activerecord.Model;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/mybatis-plus-join-test/test-kotlin/src/main/java/com/github/yulichang/test/kt/entity/ID.kt
+++ b/mybatis-plus-join-test/test-kotlin/src/main/java/com/github/yulichang/test/kt/entity/ID.kt
@@ -1,7 +1,7 @@
 package com.github.yulichang.test.kt.entity
 
 import com.baomidou.mybatisplus.annotation.TableId
-import com.baomidou.mybatisplus.extension.activerecord.Model
+import com.baomidou.mybatisplus.spring.activerecord.Model
 import lombok.Getter
 import lombok.Setter
 import java.io.Serializable

--- a/mybatis-plus-join-test/test-mapping/src/main/java/com/github/yulichang/test/mapping/service/impl/AddressServiceImpl.java
+++ b/mybatis-plus-join-test/test-mapping/src/main/java/com/github/yulichang/test/mapping/service/impl/AddressServiceImpl.java
@@ -1,6 +1,6 @@
 package com.github.yulichang.test.mapping.service.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import com.github.yulichang.test.mapping.entity.AddressDO;
 import com.github.yulichang.test.mapping.mapper.AddressMapper;
 import com.github.yulichang.test.mapping.service.AddressService;

--- a/mybatis-plus-join-test/test-mapping/src/main/java/com/github/yulichang/test/mapping/service/impl/UserServiceImpl.java
+++ b/mybatis-plus-join-test/test-mapping/src/main/java/com/github/yulichang/test/mapping/service/impl/UserServiceImpl.java
@@ -1,6 +1,6 @@
 package com.github.yulichang.test.mapping.service.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import com.github.yulichang.extension.mapping.base.MPJDeepService;
 import com.github.yulichang.test.mapping.entity.UserDO;
 import com.github.yulichang.test.mapping.mapper.UserMapper;

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <properties>
         <revision>1.5.7</revision>
-        <mybatis.plus.version>3.5.16</mybatis.plus.version>
+        <mybatis.plus.version>3.5.17</mybatis.plus.version>
 
         <jdkVersion>17</jdkVersion>
         <jdkVersion.test>17</jdkVersion.test>


### PR DESCRIPTION
## What changed

- bump the MyBatis-Plus baseline from 3.5.16 to 3.5.17
- migrate Spring-specific APIs moved from `com.baomidou.mybatisplus.extension` to `com.baomidou.mybatisplus.spring`
- fall back to the MyBatis-Plus core JAR name when runtime version metadata is absent, including Spring Boot nested-JAR URLs
- update Java and Kotlin test fixtures to use the relocated Spring APIs

## Why

MyBatis-Plus 3.5.17 relocates `IService`, `ServiceImpl`, `CrudRepository`, and `Model` into the `mybatis-plus-spring` namespace. Its published `mybatis-plus-core` JAR also omits `Implementation-Version`, so MPJ's adapter selection received a blank version and failed during `MPJInterceptor` initialization.

## Impact

The project now compiles and starts against MyBatis-Plus 3.5.17 while preserving the existing MPJ module structure and public type names.

## Validation

- `mvn -q -B -pl mybatis-plus-join-test/test-join -am -Dtest=LambdaWrapperTest -Dsurefire.failIfNoSpecifiedTests=false package`
- `mvn -q -B package` on JDK 17
- `mvn -q -B package` on JDK 21, matching the pull-request workflow
- `mvn -B -pl mybatis-plus-join-core dependency:tree -Dincludes=com.baomidou -Dverbose` confirms the effective core MyBatis-Plus dependencies resolve to 3.5.17
